### PR TITLE
Added option to checkout specific branch when cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # bower-git
+
 Replaces bower component folders with their git-repository counterpart
 
 ## Installation
@@ -18,6 +19,7 @@ $ bower-git
 
     -h, --help     output usage information
     -V, --version  output the version number
+    -b, --branch [value]  checkout specific branch (default: master)
     -v, --verbose
 ```
 
@@ -29,14 +31,24 @@ $ bower-git vendor/headjs
   Bower component "headjs" has been replaced by its git repository
 ```
 
+### Checkout specific branch
+
+Pass `--branch={branch}` to checkout specific branch uppon clone. e.g. checkout the same branch as the current one you're in.
+
+```
+$ bower-git vendor/headjs --branch=$(git rev-parse --abbrev-ref HEAD)
+  Replacing bower component with git repository...
+  Bower component "headjs" has been replaced by its git repository
+```
+
 ## Contributing
 
 Please respect the `.editorconfig`, `.jscsrc` and `.eslintrc` style guide. Basically:
 
-* UTF-8
-* Unix linebreaks
-* 4 space indentation
-* Semicolons
+-   UTF-8
+-   Unix linebreaks
+-   4 space indentation
+-   Semicolons
 
 Run:
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -10,6 +10,7 @@ program
     .version(require('../package.json').version)
     .arguments('<path>')
     .option('-v, --verbose', '')
+    .option('-b, --branch [value]', 'checkout specific branch', 'master')
     // .action(function(path) {
     //     var pathValue = path;
     // })
@@ -21,7 +22,8 @@ if (!program.args.length) {
 
 options = {
     path: program.args[0],
-    verbose: program.verbose
+    verbose: program.verbose,
+    branch: program.branch
 };
 
 // console.log(program);

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@ function run(options) {
 
     var promise;
     var folderPath = options.path;
+    var branch = options.branch;
 
     if (!folderPath) {
         // console.error(chalk.red(indent + 'ABORTING: No path provided!'));
@@ -42,6 +43,7 @@ function run(options) {
 
         var json = JSON.parse(data);
         var url;
+        var checkout = branch ? '-b ' + branch : '';
         var tmpFolderName = path.join(dirName, 'tmp' + Date.now());
 
         if (options.verbose) {
@@ -66,7 +68,7 @@ function run(options) {
             console.log(indent + 'Cloning from ' + url + ' to temporary directory...');
         }
 
-        exec('git clone ' + url + ' ' + tmpFolderName, function(err) {
+        exec('git clone ' + url + ' ' + checkout + ' ' + tmpFolderName, function(err) {
             if (err) {
                 throw err;
             }


### PR DESCRIPTION
The option to checkout a specific branch when cloning would be awesome.

Usecases:

`mrgreen-ui` is on `feature/XXX-1337-do-this`

Running

`bower-git src/platform/model-user --branch="feature/XXX-1337-do-this"`

would checkout that branch right away.